### PR TITLE
slo: Support float instead of only int counts

### DIFF
--- a/pkg/slo/api/types.go
+++ b/pkg/slo/api/types.go
@@ -33,6 +33,6 @@ type TeamResult struct {
 type TeamsResults map[string]TeamResult
 
 type Data struct {
-	Count     int  `json:"count,omitempty"`
-	PerMember bool `json:"perMember,omitempty"`
+	Count     float32 `json:"count,omitempty"`
+	PerMember bool    `json:"perMember,omitempty"`
 }

--- a/pkg/slo/slo.go
+++ b/pkg/slo/slo.go
@@ -76,9 +76,10 @@ func getCountResult(which string, bugMaps map[string]bugs.TeamMap, teamSLO map[s
 		return sloAPI.Result{}
 	}
 	current := len(bugs[team])
-	obligation := sloData.Count
+	obligation := int(sloData.Count)
 	if sloData.PerMember && teamInfo.MemberCount != 0 {
-		obligation = obligation * teamInfo.MemberCount
+		obligation32 := sloData.Count * float32(teamInfo.MemberCount)
+		obligation = int(obligation32)
 	}
 	result := sloAPI.Result{
 		Name:       which,
@@ -99,9 +100,10 @@ func getPMScoreResult(bugMap bugs.TeamMap, sloData sloAPI.Data, teamInfo teams.T
 		}
 		score += bugScore
 	}
-	obligation := sloData.Count
+	obligation := int(sloData.Count)
 	if sloData.PerMember && teamInfo.MemberCount != 0 {
-		obligation = obligation * teamInfo.MemberCount
+		obligation32 := sloData.Count * float32(teamInfo.MemberCount)
+		obligation = int(obligation32)
 	}
 	result := sloAPI.Result{
 		Name:       sloAPI.PMScore,


### PR DESCRIPTION
One team decided they wanted 1.5 blockers per engineer