### PR TITLE
slo: add CI stats from sippy

### DIFF
--- a/cmd/team-slo-results/main.go
+++ b/cmd/team-slo-results/main.go
@@ -28,9 +28,19 @@ const (
 func getTeamSLOResults(cmd *cobra.Command, orgInfo *teams.OrgData, bugData *bugs.BugData) (sloAPI.TeamsResults, error) {
 	bugMaps := slo.GetBugMaps(bugData)
 
+	currentVersion, err := slo.CurrentVersion(orgInfo.Releases)
+	if err != nil {
+		return nil, err
+	}
+	// TODO: consider more releases?
+	ciComponentMap, err := slo.GetCiComponentMap(currentVersion)
+	if err != nil {
+		return nil, err
+	}
+
 	teamsResults := make(sloAPI.TeamsResults, len(orgInfo.Teams))
 	for team, teamInfo := range orgInfo.Teams {
-		teamsResults[team] = slo.GetTeamResult(bugMaps, orgInfo, teamInfo)
+		teamsResults[team] = slo.GetTeamResult(bugMaps, ciComponentMap, orgInfo, teamInfo)
 	}
 	return teamsResults, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/openshift/build-machinery-go v0.0.0-20200512074546-3744767c4131
 	github.com/openshift/library-go v0.0.0-20200623125929-17bb296f39b8
+	github.com/openshift/sippy v0.0.0-20200925184220-ce6139994b76
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.7.1
 	github.com/sirupsen/logrus v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -390,6 +390,8 @@ github.com/openshift/build-machinery-go v0.0.0-20200512074546-3744767c4131/go.mo
 github.com/openshift/client-go v0.0.0-20200521150516-05eb9880269c/go.mod h1:kCMeo6IE4o4qvnepM9lgHQ4j/ZFfvY/N/2G/jpJdwm4=
 github.com/openshift/library-go v0.0.0-20200623125929-17bb296f39b8 h1:yvki3I4lOAY13JqjIoUInH08NAd7L3NkaA9jN+H9WDg=
 github.com/openshift/library-go v0.0.0-20200623125929-17bb296f39b8/go.mod h1:gckhmPaUyPXT9HFUIeA8YgUzn3OzM5PhS2azW+Y8VmU=
+github.com/openshift/sippy v0.0.0-20200925184220-ce6139994b76 h1:xUopbwgx78HftuYvCaM/gJGdYdrqSCLBMw+JtlhUCM0=
+github.com/openshift/sippy v0.0.0-20200925184220-ce6139994b76/go.mod h1:lx4xcqCP8/U7MoMbP9+13TCnjltG6lnBZ+No/L8csvQ=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
@@ -451,6 +453,7 @@ github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTd
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
+github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=

--- a/pkg/slo/api/types.go
+++ b/pkg/slo/api/types.go
@@ -5,6 +5,7 @@ const (
 	Blocker = "blockers"
 	All     = "total"
 	PMScore = "pmscore"
+	CI      = "ci-fail-rate"
 )
 
 var (
@@ -12,6 +13,7 @@ var (
 		Urgent,
 		Blocker,
 		PMScore,
+		CI,
 		All,
 	}
 )

--- a/vendor/github.com/openshift/sippy/pkg/apis/bugs/v1/types.go
+++ b/vendor/github.com/openshift/sippy/pkg/apis/bugs/v1/types.go
@@ -1,0 +1,22 @@
+package v1
+
+import "time"
+
+// Bug is used to represent bugs in some serialized content.  It also tracks some additional metadata.
+type Bug struct {
+	BugzillaBug  `json:",inline"`
+	Url          string `json:"url"`
+	FailureCount int    `json:"failureCount,omitempty"`
+	FlakeCount   int    `json:"flakeCount,omitempty"`
+}
+
+// BugzillaBug matches the bugzilla API.  We cannot change this and should consider writing a converter instead of having
+// a serialization we don't own.
+type BugzillaBug struct {
+	ID             int64     `json:"id"`
+	Status         string    `json:"status"`
+	LastChangeTime time.Time `json:"last_change_time"`
+	Summary        string    `json:"summary"`
+	TargetRelease  []string  `json:"target_release"`
+	Component      []string  `json:"component"`
+}

--- a/vendor/github.com/openshift/sippy/pkg/apis/sippy/v1/types.go
+++ b/vendor/github.com/openshift/sippy/pkg/apis/sippy/v1/types.go
@@ -1,0 +1,70 @@
+package v1
+
+import bugsv1 "github.com/openshift/sippy/pkg/apis/bugs/v1"
+
+// PassRate describes statistics on a pass rate
+type PassRate struct {
+	Percentage          float64 `json:"percentage"`
+	ProjectedPercentage float64 `json:"projectedPercentage,omitempty"`
+	Runs                int     `json:"runs"`
+}
+
+// SummaryAcrossAllJobs describes the category summaryacrossalljobs
+// valid keys are latest and prev
+type SummaryAcrossAllJobs struct {
+	TestExecutions     map[string]int     `json:"testExecutions"`
+	TestPassPercentage map[string]float64 `json:"testPassPercentage"`
+}
+
+// FailureGroups describes the category failuregroups
+// valid keys are latest and prev
+type FailureGroups struct {
+	JobRunsWithFailureGroup map[string]int `json:"jobRunsWithFailureGroup"`
+	AvgFailureGroupSize     map[string]int `json:"avgFailureGroupSize"`
+	MedianFailureGroupSize  map[string]int `json:"medianFailureGroupSize"`
+}
+
+// CanaryTestFailInstance describes one single instance of a canary test failure
+// passRate should have percentage (float64) and number of runs (int)
+type CanaryTestFailInstance struct {
+	Name     string   `json:"name"`
+	Url      string   `json:"url"`
+	PassRate PassRate `json:"passRate"`
+}
+
+// PassRatesByJobName is responsible for the section job pass rates by job name
+type PassRatesByJobName struct {
+	Name      string              `json:"name"`
+	Url       string              `json:"url"`
+	PassRates map[string]PassRate `json:"passRates"`
+}
+
+// MinimumPassRatesByComponent describes minimum job pass rate per BZ component
+type MinimumPassRatesByComponent struct {
+	// name is the component name
+	Name string `json:"name"`
+	// passRates are the pass rates, by "latest" and optional "prev".
+	PassRates map[string]PassRate `json:"passRates"`
+}
+
+// FailingTestBug describes a single instance of failed test with bug or failed test without bug
+// differs from failingtest in that it includes pass rates for previous days and latest days
+type FailingTestBug struct {
+	Name      string              `json:"name"`
+	Url       string              `json:"url"`
+	PassRates map[string]PassRate `json:"passRates"`
+	Bugs      []bugsv1.Bug        `json:"bugs,omitempty"`
+}
+
+// JobSummaryPlatform describes a single platform and its associated jobs, their pass rates, and failing tests
+type JobSummaryPlatform struct {
+	Platform  string              `json:"platform"`
+	PassRates map[string]PassRate `json:"passRates"`
+}
+
+// FailureGroup describes a single failure group - does not show the associated failed job names
+type FailureGroup struct {
+	Job          string `json:"job"`
+	Url          string `json:"url"`
+	TestFailures int    `json:"testFailures"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -107,6 +107,10 @@ github.com/openshift/library-go/pkg/controller/factory
 github.com/openshift/library-go/pkg/controller/fileobserver
 github.com/openshift/library-go/pkg/operator/events
 github.com/openshift/library-go/pkg/operator/v1helpers
+# github.com/openshift/sippy v0.0.0-20200925184220-ce6139994b76
+## explicit
+github.com/openshift/sippy/pkg/apis/bugs/v1
+github.com/openshift/sippy/pkg/apis/sippy/v1
 # github.com/peterbourgon/diskv v2.0.1+incompatible
 github.com/peterbourgon/diskv
 # github.com/pkg/errors v0.9.1


### PR DESCRIPTION
~~Requires https://github.com/openshift/sippy/pull/107 (using fake bump currently).~~ merged.

Default obligation is 100 ci-fail-rate now. Reasonable default will be set in shiftzilla_cfg.yaml.