### PR TITLE
pkg/bugs: Bump the current release to 4.7.0

### DIFF
--- a/pkg/bugs/bugs.go
+++ b/pkg/bugs/bugs.go
@@ -24,7 +24,7 @@ const (
 	bugDataFlagDefVal = ""
 	bugDataFlagUsage  = "Path to file containing test bug data"
 
-	CurrentRelease = "4.6.0"
+	CurrentRelease = "4.7.0"
 )
 
 type PeopleMap map[string][]*bugzilla.Bug


### PR DESCRIPTION
The train for 4.6 GA is leaving the station, and anyone with remaining 4.6 blockers will definitely know about them without the bot reminding them.

/assign @eparis