### PR TITLE
Remove .gitignore for "logs"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,20 +33,4 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-### react ###
-.DS_*
-*.log
-logs
-**/*.backup.*
-**/*.back.*
-
-node_modules
-bower_components
-
-*.sublime*
-
-psd
-thumb
-sketch
-
-# End of https://www.gitignore.io/api/go,react
+# End of https://www.gitignore.io/api/go

--- a/vendor/github.com/openshift/build-machinery-go/make/default.example.mk.help.log
+++ b/vendor/github.com/openshift/build-machinery-go/make/default.example.mk.help.log
@@ -1,0 +1,24 @@
+The following make targets are available:
+all
+build
+clean
+clean-binaries
+help
+image-ocp-cli
+images
+test
+test-unit
+update
+update-bindata
+update-codegen
+update-deps-overrides
+update-generated
+update-gofmt
+verify
+verify-bindata
+verify-codegen
+verify-deps
+verify-generated
+verify-gofmt
+verify-golint
+verify-govet

--- a/vendor/github.com/openshift/build-machinery-go/make/golang.example.mk.help.log
+++ b/vendor/github.com/openshift/build-machinery-go/make/golang.example.mk.help.log
@@ -1,0 +1,14 @@
+The following make targets are available:
+all
+build
+clean
+clean-binaries
+help
+test
+test-unit
+update
+update-gofmt
+verify
+verify-gofmt
+verify-golint
+verify-govet

--- a/vendor/github.com/openshift/build-machinery-go/make/operator.example.mk.help.log
+++ b/vendor/github.com/openshift/build-machinery-go/make/operator.example.mk.help.log
@@ -1,0 +1,25 @@
+The following make targets are available:
+all
+build
+clean
+clean-binaries
+help
+image-ocp-openshift-apiserver-operator
+images
+telepresence
+test
+test-unit
+update
+update-bindata
+update-codegen
+update-deps-overrides
+update-generated
+update-gofmt
+verify
+verify-bindata
+verify-codegen
+verify-deps
+verify-generated
+verify-gofmt
+verify-golint
+verify-govet

--- a/vendor/k8s.io/component-base/logs/OWNERS
+++ b/vendor/k8s.io/component-base/logs/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- sig-instrumentation-approvers
+reviewers:
+- sig-instrumentation-reviewers
+labels:
+- sig/instrumentation

--- a/vendor/k8s.io/component-base/logs/json/json.go
+++ b/vendor/k8s.io/component-base/logs/json/json.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"os"
+	"time"
+
+	"github.com/go-logr/logr"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// Inspired from https://github.com/go-logr/zapr, some functions is copy from the repo.
+
+var (
+	// JSONLogger is global json log format logr
+	JSONLogger logr.Logger
+
+	// timeNow stubbed out for testing
+	timeNow = time.Now
+)
+
+// zapLogger is a logr.Logger that uses Zap to record log.
+type zapLogger struct {
+	// NB: this looks very similar to zap.SugaredLogger, but
+	// deals with our desire to have multiple verbosity levels.
+	l   *zap.Logger
+	lvl int
+}
+
+// implement logr.Logger
+var _ logr.Logger = &zapLogger{}
+
+// Enabled should always return true
+func (l *zapLogger) Enabled() bool {
+	return true
+}
+
+// Info write message to error level log
+func (l *zapLogger) Info(msg string, keysAndVals ...interface{}) {
+	entry := zapcore.Entry{
+		Time:    timeNow(),
+		Message: msg,
+	}
+	checkedEntry := l.l.Core().Check(entry, nil)
+	checkedEntry.Write(l.handleFields(keysAndVals)...)
+}
+
+// dPanic write message to DPanicLevel level log
+// we need implement this because unit test case need stub time.Now
+// otherwise the ts field always changed
+func (l *zapLogger) dPanic(msg string) {
+	entry := zapcore.Entry{
+		Level:   zapcore.DPanicLevel,
+		Time:    timeNow(),
+		Message: msg,
+	}
+	checkedEntry := l.l.Core().Check(entry, nil)
+	checkedEntry.Write(zap.Int("v", l.lvl))
+}
+
+// handleFields converts a bunch of arbitrary key-value pairs into Zap fields.  It takes
+// additional pre-converted Zap fields, for use with automatically attached fields, like
+// `error`.
+func (l *zapLogger) handleFields(args []interface{}, additional ...zap.Field) []zap.Field {
+	// a slightly modified version of zap.SugaredLogger.sweetenFields
+	if len(args) == 0 {
+		// fast-return if we have no suggared fields.
+		return append(additional, zap.Int("v", l.lvl))
+	}
+
+	// unlike Zap, we can be pretty sure users aren't passing structured
+	// fields (since logr has no concept of that), so guess that we need a
+	// little less space.
+	fields := make([]zap.Field, 0, len(args)/2+len(additional)+1)
+	fields = append(fields, zap.Int("v", l.lvl))
+	for i := 0; i < len(args)-1; i += 2 {
+		// check just in case for strongly-typed Zap fields, which is illegal (since
+		// it breaks implementation agnosticism), so we can give a better error message.
+		if _, ok := args[i].(zap.Field); ok {
+			l.dPanic("strongly-typed Zap Field passed to logr")
+			break
+		}
+
+		// process a key-value pair,
+		// ensuring that the key is a string
+		key, val := args[i], args[i+1]
+		keyStr, isString := key.(string)
+		if !isString {
+			// if the key isn't a string, stop logging
+			l.dPanic("non-string key argument passed to logging, ignoring all later arguments")
+			break
+		}
+
+		fields = append(fields, zap.Any(keyStr, val))
+	}
+
+	return append(fields, additional...)
+}
+
+// Error write log message to error level
+func (l *zapLogger) Error(err error, msg string, keysAndVals ...interface{}) {
+	entry := zapcore.Entry{
+		Level:   zapcore.ErrorLevel,
+		Time:    timeNow(),
+		Message: msg,
+	}
+	checkedEntry := l.l.Core().Check(entry, nil)
+	checkedEntry.Write(l.handleFields(keysAndVals, handleError(err))...)
+}
+
+// V return info logr.Logger  with specified level
+func (l *zapLogger) V(level int) logr.Logger {
+	return &zapLogger{
+		lvl: l.lvl + level,
+		l:   l.l,
+	}
+}
+
+// WithValues return logr.Logger with some keys And Values
+func (l *zapLogger) WithValues(keysAndValues ...interface{}) logr.Logger {
+	l.l = l.l.With(l.handleFields(keysAndValues)...)
+	return l
+}
+
+// WithName return logger Named with specified name
+func (l *zapLogger) WithName(name string) logr.Logger {
+	l.l = l.l.Named(name)
+	return l
+}
+
+// encoderConfig config zap encodetime format
+var encoderConfig = zapcore.EncoderConfig{
+	MessageKey: "msg",
+
+	TimeKey:    "ts",
+	EncodeTime: zapcore.EpochMillisTimeEncoder,
+}
+
+// NewJSONLogger creates a new json logr.Logger using the given Zap Logger to log.
+func NewJSONLogger(w zapcore.WriteSyncer) logr.Logger {
+	l, _ := zap.NewProduction()
+	if w == nil {
+		w = os.Stdout
+	}
+	log := l.WithOptions(zap.AddCallerSkip(1),
+		zap.WrapCore(
+			func(zapcore.Core) zapcore.Core {
+				return zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), zapcore.AddSync(w), zapcore.DebugLevel)
+			}))
+	return &zapLogger{
+		l: log,
+	}
+}
+
+func handleError(err error) zap.Field {
+	return zap.NamedError("err", err)
+}
+
+func init() {
+	JSONLogger = NewJSONLogger(nil)
+}

--- a/vendor/k8s.io/component-base/logs/logs.go
+++ b/vendor/k8s.io/component-base/logs/logs.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+)
+
+const logFlushFreqFlagName = "log-flush-frequency"
+
+var logFlushFreq = pflag.Duration(logFlushFreqFlagName, 5*time.Second, "Maximum number of seconds between log flushes")
+
+func init() {
+	klog.InitFlags(flag.CommandLine)
+}
+
+// AddFlags registers this package's flags on arbitrary FlagSets, such that they point to the
+// same value as the global flags.
+func AddFlags(fs *pflag.FlagSet) {
+	fs.AddFlag(pflag.Lookup(logFlushFreqFlagName))
+}
+
+// KlogWriter serves as a bridge between the standard log package and the glog package.
+type KlogWriter struct{}
+
+// Write implements the io.Writer interface.
+func (writer KlogWriter) Write(data []byte) (n int, err error) {
+	klog.InfoDepth(1, string(data))
+	return len(data), nil
+}
+
+// InitLogs initializes logs the way we want for kubernetes.
+func InitLogs() {
+	log.SetOutput(KlogWriter{})
+	log.SetFlags(0)
+	// The default glog flush interval is 5 seconds.
+	go wait.Forever(klog.Flush, *logFlushFreq)
+}
+
+// FlushLogs flushes logs immediately.
+func FlushLogs() {
+	klog.Flush()
+}
+
+// NewLogger creates a new log.Logger which sends logs to klog.Info.
+func NewLogger(prefix string) *log.Logger {
+	return log.New(KlogWriter{}, prefix, 0)
+}
+
+// GlogSetter is a setter to set glog level.
+func GlogSetter(val string) (string, error) {
+	var level klog.Level
+	if err := level.Set(val); err != nil {
+		return "", fmt.Errorf("failed set klog.logging.verbosity %s: %v", val, err)
+	}
+	return fmt.Sprintf("successfully set klog.logging.verbosity to %s", val), nil
+}

--- a/vendor/k8s.io/component-base/logs/options.go
+++ b/vendor/k8s.io/component-base/logs/options.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/pflag"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	logFormatFlagName = "logging-format"
+	defaultLogFormat  = "text"
+)
+
+// List of logs (k8s.io/klog + k8s.io/component-base/logs) flags supported by all logging formats
+var supportedLogsFlags = map[string]struct{}{
+	"v": {},
+	// TODO: support vmodule after 1.19 Alpha
+}
+
+// Options has klog format parameters
+type Options struct {
+	LogFormat string
+}
+
+// NewOptions return new klog options
+func NewOptions() *Options {
+	return &Options{
+		LogFormat: defaultLogFormat,
+	}
+}
+
+// Validate verifies if any unsupported flag is set
+// for non-default logging format
+func (o *Options) Validate() []error {
+	errs := []error{}
+	if o.LogFormat != defaultLogFormat {
+		allFlags := unsupportedLoggingFlags()
+		for _, fname := range allFlags {
+			if flagIsSet(fname) {
+				errs = append(errs, fmt.Errorf("non-default logging format doesn't honor flag: %s", fname))
+			}
+		}
+	}
+	if _, err := o.Get(); err != nil {
+		errs = append(errs, fmt.Errorf("unsupported log format: %s", o.LogFormat))
+	}
+	return errs
+}
+
+func flagIsSet(name string) bool {
+	f := flag.Lookup(name)
+	if f != nil {
+		return f.DefValue != f.Value.String()
+	}
+	pf := pflag.Lookup(name)
+	if pf != nil {
+		return pf.DefValue != pf.Value.String()
+	}
+	panic("failed to lookup unsupported log flag")
+}
+
+// AddFlags add logging-format flag
+func (o *Options) AddFlags(fs *pflag.FlagSet) {
+	unsupportedFlags := fmt.Sprintf("--%s", strings.Join(unsupportedLoggingFlags(), ", --"))
+	formats := fmt.Sprintf(`"%s"`, strings.Join(logRegistry.List(), `", "`))
+	fs.StringVar(&o.LogFormat, logFormatFlagName, defaultLogFormat, fmt.Sprintf("Sets the log format. Permitted formats: %s.\nNon-default formats don't honor these flags: %s.\nNon-default choices are currently alpha and subject to change without warning.", formats, unsupportedFlags))
+
+	// No new log formats should be added after generation is of flag options
+	logRegistry.Freeze()
+}
+
+// Apply set klog logger from LogFormat type
+func (o *Options) Apply() {
+	// if log format not exists, use nil loggr
+	loggr, _ := o.Get()
+	klog.SetLogger(loggr)
+}
+
+// Get logger with LogFormat field
+func (o *Options) Get() (logr.Logger, error) {
+	return logRegistry.Get(o.LogFormat)
+}
+
+func unsupportedLoggingFlags() []string {
+	allFlags := []string{}
+
+	// k8s.io/klog flags
+	fs := &flag.FlagSet{}
+	klog.InitFlags(fs)
+	fs.VisitAll(func(flag *flag.Flag) {
+		if _, found := supportedLogsFlags[flag.Name]; !found {
+			allFlags = append(allFlags, flag.Name)
+		}
+	})
+
+	// k8s.io/component-base/logs flags
+	pfs := &pflag.FlagSet{}
+	AddFlags(pfs)
+	pfs.VisitAll(func(flag *pflag.Flag) {
+		if _, found := supportedLogsFlags[flag.Name]; !found {
+			allFlags = append(allFlags, flag.Name)
+		}
+	})
+	return allFlags
+}

--- a/vendor/k8s.io/component-base/logs/registry.go
+++ b/vendor/k8s.io/component-base/logs/registry.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/go-logr/logr"
+	json "k8s.io/component-base/logs/json"
+)
+
+const (
+	jsonLogFormat = "json"
+)
+
+var logRegistry = NewLogFormatRegistry()
+
+// LogFormatRegistry store klog format registry
+type LogFormatRegistry struct {
+	registry map[string]logr.Logger
+	frozen   bool
+}
+
+// NewLogFormatRegistry return new init LogFormatRegistry struct
+func NewLogFormatRegistry() *LogFormatRegistry {
+	return &LogFormatRegistry{
+		registry: make(map[string]logr.Logger),
+		frozen:   false,
+	}
+}
+
+// Register new log format registry to global logRegistry
+func (lfr *LogFormatRegistry) Register(name string, logger logr.Logger) error {
+	if lfr.frozen {
+		return fmt.Errorf("log format is frozen, unable to register log format")
+	}
+	if _, ok := lfr.registry[name]; ok {
+		return fmt.Errorf("log format: %s already exists", name)
+	}
+	lfr.registry[name] = logger
+	return nil
+}
+
+// Get specified log format logger
+func (lfr *LogFormatRegistry) Get(name string) (logr.Logger, error) {
+	re, ok := lfr.registry[name]
+	if !ok {
+		return nil, fmt.Errorf("log format: %s does not exists", name)
+	}
+	return re, nil
+}
+
+// Set specified log format logger
+func (lfr *LogFormatRegistry) Set(name string, logger logr.Logger) error {
+	if lfr.frozen {
+		return fmt.Errorf("log format is frozen, unable to set log format")
+	}
+
+	lfr.registry[name] = logger
+	return nil
+}
+
+// Delete specified log format logger
+func (lfr *LogFormatRegistry) Delete(name string) error {
+	if lfr.frozen {
+		return fmt.Errorf("log format is frozen, unable to delete log format")
+	}
+
+	delete(lfr.registry, name)
+	return nil
+}
+
+// List names of registered log formats (sorted)
+func (lfr *LogFormatRegistry) List() []string {
+	formats := make([]string, 0, len(lfr.registry))
+	for f := range lfr.registry {
+		formats = append(formats, f)
+	}
+	sort.Strings(formats)
+	return formats
+}
+
+// Freeze freezes the log format registry
+func (lfr *LogFormatRegistry) Freeze() {
+	lfr.frozen = true
+}
+func init() {
+	// Text format is default klog format
+	logRegistry.Register(defaultLogFormat, nil)
+	logRegistry.Register(jsonLogFormat, json.JSONLogger)
+}


### PR DESCRIPTION
This was added to ignore some files typical in react applications. But it
meant that a few files in vendor were not committed to git. Since create-react-app
made it's own .gitignore in it's own directory this .gitignore at the top
level is not valuable