### PR TITLE
bug-automation: fix message when a blocker+ has no target release

### DIFF
--- a/cmd/bug-automation/generate/main.go
+++ b/cmd/bug-automation/generate/main.go
@@ -210,10 +210,7 @@ func blockerPlusWithoutTargetReleaseAction() bugzilla.BugUpdate {
 	update.MinorUpdate = false
 	update.Comment = &bugzilla.BugComment{
 		Private: true,
-		Body: `This bug sets Target Release equal to a z-stream but has no bug in the 'Depends On' field. As such this is not a valid bug state and the target release is being unset.
-
-Any bug targeting 4.1.z must have a bug targeting 4.2 in 'Depends On.'
-Similarly, any bug targeting 4.2.z must have a bug with Target Release of 4.3 in 'Depends On.'`,
+		Body:    `This bug sets blocker+ without setting a Target Release. This is an invalid state as it is impossible to determine what is being blocked. Please be sure to set Priority, Severity, and Target Release before you attempt to set blocker+`,
 	}
 	return update
 }

--- a/cmd/bug-automation/operations/blockerPlusWithoutTargetRelease.yaml
+++ b/cmd/bug-automation/operations/blockerPlusWithoutTargetRelease.yaml
@@ -33,11 +33,7 @@ query:
   - '---'
 update:
   comment:
-    body: |-
-      This bug sets Target Release equal to a z-stream but has no bug in the 'Depends On' field. As such this is not a valid bug state and the target release is being unset.
-
-      Any bug targeting 4.1.z must have a bug targeting 4.2 in 'Depends On.'
-      Similarly, any bug targeting 4.2.z must have a bug with Target Release of 4.3 in 'Depends On.'
+    body: This bug sets blocker+ without setting a Target Release. This is an invalid state as it is impossible to determine what is being blocked. Please be sure to set Priority, Severity, and Target Release before you attempt to set blocker+
     is_private: true
   flags:
   - name: blocker

--- a/cmd/bug-automation/operations/bugsTargetOldZero.yaml
+++ b/cmd/bug-automation/operations/bugsTargetOldZero.yaml
@@ -35,8 +35,6 @@ query:
   - 4.6.0
 update:
   comment:
-    body: Unsetting the target release because this bug targets a .0 release which
-      has already shipped. For example it may target 4.2.0. Since 4.2.0 has already
-      shipped such bugs may instead wish to target a future 4.2.z.
+    body: Unsetting the target release because this bug targets a .0 release which has already shipped. For example it may target 4.2.0. Since 4.2.0 has already shipped such bugs may instead wish to target a future 4.2.z.
     is_private: true
   target_release: '---'

--- a/cmd/bug-automation/operations/targetReleaseWithoutSeverity.yaml
+++ b/cmd/bug-automation/operations/targetReleaseWithoutSeverity.yaml
@@ -34,9 +34,6 @@ query:
   - ON_DEV
 update:
   comment:
-    body: This bug has set a target release without specifying a severity. As part
-      of triage when determining the importance of bugs a severity should be specified.
-      Since these bugs have not been properly triaged we are removing the target release.
-      Teams will need to add a severity before setting the target release again.
+    body: This bug has set a target release without specifying a severity. As part of triage when determining the importance of bugs a severity should be specified. Since these bugs have not been properly triaged we are removing the target release. Teams will need to add a severity before setting the target release again.
     is_private: true
   target_release: '---'


### PR DESCRIPTION
I did a copy/paste of another message and didn't write a correct message
for this rule.