### PR TITLE
teams/slo: calculate the current version in teams not in slo

### DIFF
--- a/cmd/team-slo-results/main.go
+++ b/cmd/team-slo-results/main.go
@@ -28,10 +28,11 @@ const (
 func getTeamSLOResults(cmd *cobra.Command, orgInfo *teams.OrgData, bugData *bugs.BugData) (sloAPI.TeamsResults, error) {
 	bugMaps := slo.GetBugMaps(bugData)
 
-	currentVersion, err := slo.CurrentVersion(orgInfo.Releases)
+	currentVersion, err := orgInfo.CurrentVersion()
 	if err != nil {
 		return nil, err
 	}
+
 	// TODO: consider more releases?
 	ciComponentMap, err := slo.GetCiComponentMap(currentVersion)
 	if err != nil {

--- a/pkg/slo/slo.go
+++ b/pkg/slo/slo.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/kr/pretty"
@@ -98,43 +96,6 @@ func GetCiComponentMap(version string) (map[string]sippyv1.MinimumPassRatesByCom
 		result[c.Name] = c
 	}
 	return result, nil
-}
-
-// CurrentVersion returns the lowest x.y version that has a x.y.0 target.
-func CurrentVersion(releases map[string]teams.ReleaseInfo) (string, error) {
-	var all []string
-	var active []string
-	var order []string
-	for _, v := range releases {
-		all = append(all, v.Name)
-		onlyZ := true
-		for _, target := range v.Targets {
-			if !strings.HasSuffix(target, ".z") {
-				onlyZ = false
-				break
-			}
-		}
-		if onlyZ {
-			continue
-		}
-
-		vs := strings.Split(v.Name, ".")
-		if len(vs) < 2 {
-			continue
-		}
-		active = append(active, fmt.Sprintf("%s.%s", vs[0], vs[1]))
-		if len(vs[1]) == 1 {
-			vs[1] = "0" + vs[1]
-		}
-		order = append(order, vs[0]+vs[1])
-	}
-	if len(active) == 0 {
-		return "", fmt.Errorf("no release found that has a x.y.0 target version: %v", all)
-	}
-	sort.Slice(active, func(i, j int) bool {
-		return order[i] < order[j]
-	})
-	return active[0], nil
 }
 
 func getCountResult(which string, bugMaps map[string]bugs.TeamMap, teamSLO map[string]sloAPI.Data, teamInfo teams.TeamInfo) sloAPI.Result {


### PR DESCRIPTION
This really just moves the check so it could be used by others.