### PR TITLE
Add customer-case escalation SLO

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go v0.65.0 // indirect
 	github.com/boltdb/bolt v1.3.1
 	github.com/davecgh/go-spew v1.1.1
-	github.com/eparis/bugzilla v0.0.0-20201022181800-66527237a3e8
+	github.com/eparis/bugzilla v0.0.0-20201209172217-3e772538609a
 	github.com/eparis/goSmartSheet v0.0.6
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/eparis/bugzilla v0.0.0-20201022181800-66527237a3e8 h1:3LAlL+OAqYlC5kFfwVsG58w6dSYoqzAjdIAE71TV87Y=
-github.com/eparis/bugzilla v0.0.0-20201022181800-66527237a3e8/go.mod h1:rL9T9C00qg+aIkHUu2ENFSP49Wx9KwF+uSSF0rml5KQ=
+github.com/eparis/bugzilla v0.0.0-20201209172217-3e772538609a h1:9fVDFZV2yhzVgatwk3CCvMNW0DtPJwqLj10hkq9rWpI=
+github.com/eparis/bugzilla v0.0.0-20201209172217-3e772538609a/go.mod h1:rL9T9C00qg+aIkHUu2ENFSP49Wx9KwF+uSSF0rml5KQ=
 github.com/eparis/goSmartSheet v0.0.6 h1:B3jSE/bXv2A2NASBVRRCxzyL30ABA8h3SX58ZyT5m8E=
 github.com/eparis/goSmartSheet v0.0.6/go.mod h1:ObuQCSYRvlJCeDfWRHO1dnrslGrtD2hLc9d2VdVWPEM=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=

--- a/pkg/bugs/bugs.go
+++ b/pkg/bugs/bugs.go
@@ -229,6 +229,26 @@ func (orig *BugData) FilterBlocker() *BugData {
 	return orig.FilterByFlag(BlockerFlagName, BlockerFlagTrue)
 }
 
+func (orig *BugData) FilterUrgentCustomerCases() *BugData {
+	bd := orig.clone()
+	bugs := bd.GetBugs()
+
+	filtered := []*Bug{}
+	for _, bug := range bugs {
+		// bugs with customer case and not explicitly deprioritized
+		if (bug.Severity == "urgent" && bug.Priority == "unspecified") || bug.Priority == "urgent" {
+			for _, el := range bug.ExternalBugs {
+				if el.Type.Type == "SFDC" {
+					filtered = append(filtered, bug)
+					break
+				}
+			}
+		}
+	}
+	bd.set(filtered)
+	return bd
+}
+
 func (orig *BugData) FilterByTeams(teams []string) *BugData {
 	bd := orig.clone()
 	teamMap := bd.GetTeamMap()
@@ -335,7 +355,7 @@ func getAllOpenBugsQuery() bugzilla.Query {
 		Classification: []string{"Red Hat"},
 		Product:        []string{"OpenShift Container Platform"},
 		Status:         []string{"NEW", "ASSIGNED", "POST", "ON_DEV", "MODIFIED"},
-		IncludeFields:  []string{"id", "summary", "status", "severity", "priority", "assigned_to", "target_release", "component", "sub_components", "keywords", "cf_pm_score", "flags"},
+		IncludeFields:  []string{"id", "summary", "status", "severity", "priority", "assigned_to", "target_release", "component", "sub_components", "keywords", "cf_pm_score", "flags", "external_bugs"},
 		Advanced: []bugzilla.AdvancedQuery{
 			{
 				Field:  "component",

--- a/pkg/slo/api/types.go
+++ b/pkg/slo/api/types.go
@@ -1,16 +1,18 @@
 package sloAPI
 
 const (
-	Urgent  = "urgents"
-	Blocker = "blockers"
-	All     = "total"
-	PMScore = "pmscore"
-	CI      = "ci-fail-rate"
+	Urgent              = "urgents"
+	Blocker             = "blockers"
+	UrgentCustomerCases = "urgent-customer-cases"
+	All                 = "total"
+	PMScore             = "pmscore"
+	CI                  = "ci-fail-rate"
 )
 
 var (
 	OrderedSLOs = []string{
 		Urgent,
+		UrgentCustomerCases,
 		Blocker,
 		PMScore,
 		CI,

--- a/pkg/slo/slo.go
+++ b/pkg/slo/slo.go
@@ -62,9 +62,10 @@ func GetTeamsResults(cmd *cobra.Command) (*sloAPI.TeamsResults, error) {
 
 func GetBugMaps(bugData *bugs.BugData) map[string]bugs.TeamMap {
 	bugMaps := map[string]bugs.TeamMap{
-		sloAPI.All:     bugData.GetTeamMap(),
-		sloAPI.Urgent:  bugData.FilterBySeverity([]string{"urgent"}).GetTeamMap(),
-		sloAPI.Blocker: bugData.FilterBlocker().GetTeamMap(),
+		sloAPI.All:                 bugData.GetTeamMap(),
+		sloAPI.Urgent:              bugData.FilterBySeverity([]string{"urgent"}).GetTeamMap(),
+		sloAPI.Blocker:             bugData.FilterBlocker().GetTeamMap(),
+		sloAPI.UrgentCustomerCases: bugData.FilterUrgentCustomerCases().GetTeamMap(),
 	}
 	return bugMaps
 }
@@ -192,6 +193,8 @@ func GetTeamResult(bugMaps map[string]bugs.TeamMap, ciComponentsMap map[string]s
 		case sloAPI.All:
 			result = getCountResult(which, bugMaps, teamSLO, teamInfo)
 		case sloAPI.Urgent:
+			result = getCountResult(which, bugMaps, teamSLO, teamInfo)
+		case sloAPI.UrgentCustomerCases:
 			result = getCountResult(which, bugMaps, teamSLO, teamInfo)
 		case sloAPI.Blocker:
 			result = getCountResult(which, bugMaps, teamSLO, teamInfo)

--- a/vendor/github.com/eparis/bugzilla/fake.go
+++ b/vendor/github.com/eparis/bugzilla/fake.go
@@ -78,10 +78,23 @@ func (c *Fake) Search(query Query) ([]*Bug, error) {
 	return bugs, nil
 }
 
-// GetBug retrieves the external bugs for the Bugzilla bug,
+// GetExternalBugPRsOnBug retrieves the external bugs for the Bugzilla bug,
 // if registered, or an error, if set, or responds with an
-// error that matches IsNotFound
+// error that matches IsNotFound. It filters them by Github PRs.
 func (c *Fake) GetExternalBugPRsOnBug(id int) ([]ExternalBug, error) {
+	if c.BugErrors.Has(id) {
+		return nil, errors.New("injected error adding external bug to bug")
+	}
+	if _, exists := c.Bugs[id]; exists {
+		return c.ExternalBugs[id], nil
+	}
+	return nil, &requestError{statusCode: http.StatusNotFound, message: "bug not registered in the fake"}
+}
+
+// GetExternalBugs retrieves the external bugs for the Bugzilla bug,
+// if registered, or an error, if set, or responds with an
+// error that matches IsNotFound.
+func (c *Fake) GetExternalBugs(id int) ([]ExternalBug, error) {
 	if c.BugErrors.Has(id) {
 		return nil, errors.New("injected error adding external bug to bug")
 	}

--- a/vendor/github.com/eparis/bugzilla/test_server.go
+++ b/vendor/github.com/eparis/bugzilla/test_server.go
@@ -150,6 +150,10 @@ func (tc testClient) GetExternalBugPRsOnBug(_ int) ([]ExternalBug, error) {
 	return []ExternalBug{}, nil
 }
 
+func (tc testClient) GetExternalBugs(_ int) ([]ExternalBug, error) {
+	return []ExternalBug{}, nil
+}
+
 func (tc testClient) GetBug(id int) (*Bug, error) {
 	srv := tc.getTestServer(tc.path)
 	defer srv.Close()

--- a/vendor/github.com/eparis/bugzilla/types.go
+++ b/vendor/github.com/eparis/bugzilla/types.go
@@ -111,6 +111,10 @@ type Bug struct {
 	Whiteboard string `json:"whiteboard,omitempty"`
 	// DevelWhiteboard is the value of the "devel whiteboard" field on the bug.
 	DevelWhiteboard string `json:"cf_devel_whiteboard,omitempty"`
+	// Escalation is set to "Yes" when this bug is escalated.
+	Escalation string `json:"cf_cust_facing,omitempty"`
+	// ExternalBugs is a list of references to other trackers.
+	ExternalBugs []ExternalBug `json:"external_bugs,omitempty"`
 }
 
 type Comment struct {
@@ -246,7 +250,12 @@ type ExternalBug struct {
 	BugzillaBugID int `json:"bug_id"`
 	// ExternalBugID is a unique identifier for the bug under the tracker
 	ExternalBugID string `json:"ext_bz_bug_id"`
-	// The following fields are parsed from the external bug identifier
+	// ExternalDescription is the description in the external bug system
+	ExternalDescription string `json:"ext_description"`
+	// ExternalPriority is the priority in the external bug system
+	ExternalPriority string `json:"ext_priority"`
+
+	// The following fields are parsed from the external bug identifier for github pulls. These are only filled by GetExternalBugPRsOnBug.
 	Org, Repo string
 	Num       int
 }
@@ -255,6 +264,10 @@ type ExternalBug struct {
 type ExternalBugType struct {
 	// URL is the identifying URL for this tracker
 	URL string `json:"url"`
+	// Description is the tracker name
+	Description string `json:"description"`
+	// Type is the key for the external bug type
+	Type string `json:"type"`
 }
 
 // AddExternalBugParameters are the parameters required to add an external

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -20,7 +20,7 @@ github.com/davecgh/go-spew/spew
 # github.com/emicklei/go-restful v2.9.5+incompatible
 github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
-# github.com/eparis/bugzilla v0.0.0-20201022181800-66527237a3e8
+# github.com/eparis/bugzilla v0.0.0-20201207155830-bdebb1b9b262 => github.com/sttts/bugzilla v0.0.0-20201207155830-bdebb1b9b262
 ## explicit
 github.com/eparis/bugzilla
 # github.com/eparis/goSmartSheet v0.0.6
@@ -684,3 +684,4 @@ sigs.k8s.io/kustomize/pkg/types
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
+# github.com/eparis/bugzilla => github.com/sttts/bugzilla v0.0.0-20201207155830-bdebb1b9b262


### PR DESCRIPTION
~~Requires https://github.com/eparis/bugzilla/pull/14.~~

This is adding an `urgent-customer-cases` SLI counting the BZs with linked customer case and urgent priority.

Reasoning: these BZs are nearly always multi-day or multi-week efforts and reflect critical, production outages on the customer side needing immediate attention. This has huge influence on the well-being of the group B teams (distraction from other assigned and planned tasks) and on the happiness of individual engineers (having multiple of these BZs assigned means very high stress level).