### PR TITLE
Do not automatically set blocker? on z-stream bugs

### DIFF
--- a/cmd/bug-automation/generate/main.go
+++ b/cmd/bug-automation/generate/main.go
@@ -183,12 +183,29 @@ func targetReleaseWithoutSeverityUpdate() bugzilla.BugUpdate {
 
 func needsBlockerFlagQuery() bugzilla.Query {
 	query := defaultQuery()
-	query.Advanced = append(query.Advanced, bugzilla.AdvancedQuery{
-		Field:  "flagtypes.name",
-		Op:     "substring",
-		Value:  bugs.BlockerFlagName,
-		Negate: true,
-	})
+	query.Advanced = append(query.Advanced, []bugzilla.AdvancedQuery{
+		{
+			Field:  "flagtypes.name",
+			Op:     "substring",
+			Value:  bugs.BlockerFlagName,
+			Negate: true,
+		},
+		{
+			Field: "target_release",
+			Op:    "notregexp",
+			Value: `^4\.[0-9]+\.z$`,
+		},
+		{
+			Field: "version",
+			Op:    "notregexp",
+			Value: `^2\.`,
+		},
+		{
+			Field: "version",
+			Op:    "notregexp",
+			Value: `^3\.`,
+		},
+	}...)
 	return query
 }
 

--- a/cmd/bug-automation/operations/bugsNeedBlockerFlagPriority.yaml
+++ b/cmd/bug-automation/operations/bugsNeedBlockerFlagPriority.yaml
@@ -19,6 +19,15 @@ query:
     negate: true
     op: substring
     value: blocker
+  - field: target_release
+    op: notregexp
+    value: ^4\.[0-9]+\.z$
+  - field: version
+    op: notregexp
+    value: ^2\.
+  - field: version
+    op: notregexp
+    value: ^3\.
   classification:
   - Red Hat
   include_fields:

--- a/cmd/bug-automation/operations/bugsNeedBlockerFlagSeverity.yaml
+++ b/cmd/bug-automation/operations/bugsNeedBlockerFlagSeverity.yaml
@@ -19,6 +19,15 @@ query:
     negate: true
     op: substring
     value: blocker
+  - field: target_release
+    op: notregexp
+    value: ^4\.[0-9]+\.z$
+  - field: version
+    op: notregexp
+    value: ^2\.
+  - field: version
+    op: notregexp
+    value: ^3\.
   classification:
   - Red Hat
   include_fields:


### PR DESCRIPTION
The vast vast majority of z-stream bugs are not blockers and the cases
when they are are VERY rare. As such it is a waste of our team's time to
mechanically be required to add blocker- to every one. Instead just stop
setting blocker? at all on z-stream bugs and people can directly add
blocker+ if somthing is super critical to blocker z-streams