### PR TITLE
Fix removeReviewedInSprint query

### DIFF
--- a/cmd/bug-automation/operations/removeReviewedInSprint.yaml
+++ b/cmd/bug-automation/operations/removeReviewedInSprint.yaml
@@ -18,7 +18,7 @@ query:
   - field: flagtypes.name
     negate: true
     op: substring
-    value: reviewed-in-sprint+
+    value: reviewed-in-sprint-
   classification:
   - Red Hat
   include_fields:


### PR DESCRIPTION
removeReviewedInSprint should query BZs that don't have the flag `reviewed-in-sprint-` and set this flag.