### PR TITLE
bug-automation: fix test to mass remove reviewed-in-sprint

### DIFF
--- a/cmd/bug-automation/generate/main.go
+++ b/cmd/bug-automation/generate/main.go
@@ -93,10 +93,9 @@ func bugsWithUpcomingSprintQuery() bugzilla.Query {
 func bugsWithReviewedInSprintFlagQuery() bugzilla.Query {
 	query := defaultQuery()
 	query.Advanced = append(query.Advanced, bugzilla.AdvancedQuery{
-		Field:  "flagtypes.name",
-		Op:     "substring",
-		Value:  bugs.ReviewedInSprintFlagName + bugs.FlagTrue,
-		Negate: true,
+		Field: "flagtypes.name",
+		Op:    "equals",
+		Value: bugs.ReviewedInSprintFlagName + bugs.FlagTrue,
 	})
 	return query
 }

--- a/cmd/bug-automation/operations/removeReviewedInSprint.yaml
+++ b/cmd/bug-automation/operations/removeReviewedInSprint.yaml
@@ -16,8 +16,7 @@ query:
     op: equals
     value: odo
   - field: flagtypes.name
-    negate: true
-    op: substring
+    op: equals
     value: reviewed-in-sprint+
   classification:
   - Red Hat


### PR DESCRIPTION
It was testing for the flag not being set, instead of for the flag being
set