### PR TITLE
bug-automation: cleanup rules for zNoDepends around logging

### DIFF
--- a/cmd/bug-automation/operations/zNoDepends.yaml
+++ b/cmd/bug-automation/operations/zNoDepends.yaml
@@ -6,10 +6,6 @@ query:
   - field: component
     negate: true
     op: equals
-    value: Logging
-  - field: component
-    negate: true
-    op: equals
     value: Documentation
   - field: component
     negate: true


### PR DESCRIPTION
The file was updated manually and then via the genetator. Clean it up to
only be updated via the generator.