### PR TITLE
cmd/team-slo-results: Only include blocked-on-engineering bugs

### DIFF
--- a/cmd/bug-automation/generate/main.go
+++ b/cmd/bug-automation/generate/main.go
@@ -19,24 +19,11 @@ var (
 	testBugs = []string{}
 )
 
-func onEngineeringStatus() []string {
-	return []string{
-		"NEW",
-		"ASSIGNED",
-		"POST",
-		"ON_DEV",
-	}
-}
-
-func allOpenStatus() []string {
-	return append(onEngineeringStatus(), "MODIFIED", "ON_QA")
-}
-
 func defaultQuery() bugzilla.Query {
 	query := bugzilla.Query{
 		Classification: []string{"Red Hat"},
 		Product:        []string{"OpenShift Container Platform"},
-		Status:         onEngineeringStatus(),
+		Status:         bugs.OnEngineeringStatus(),
 		Advanced: []bugzilla.AdvancedQuery{
 			{
 				Field:  "component",
@@ -84,7 +71,7 @@ func bugsTargetOldZeroUpdate() bugzilla.BugUpdate {
 
 func bugsWithUpcomingSprintQuery() bugzilla.Query {
 	query := defaultQuery()
-	query.Status = allOpenStatus()
+	query.Status = bugs.AllOpenStatus()
 	query.Keywords = []string{"UpcomingSprint"}
 	query.KeywordsType = "allwords"
 	return query

--- a/cmd/team-slo-results/main.go
+++ b/cmd/team-slo-results/main.go
@@ -91,6 +91,7 @@ func doMain(cmd *cobra.Command) error {
 		return err
 	}
 	bugData.Reconciler(errs)
+	bugData = bugData.FilterByStatus(bugs.OnEngineeringStatus())
 
 	serveResults := &sloAPI.TeamsResults{}
 

--- a/pkg/blockerslack/reporters/blockers/blockers_reporter.go
+++ b/pkg/blockerslack/reporters/blockers/blockers_reporter.go
@@ -273,6 +273,8 @@ func (c *BlockersReporter) sync(ctx context.Context, syncCtx factory.SyncContext
 		return err
 	}
 
+	c.bugData = c.bugData.FilterByStatus(bugs.OnEngineeringStatus())
+
 	peopleNotificationMap, teamNotificationMap := Report(ctx, c.orgData, c.bugData, syncCtx.Recorder(), &c.config)
 
 	for person, results := range peopleNotificationMap {

--- a/pkg/bugs/bugs.go
+++ b/pkg/bugs/bugs.go
@@ -338,11 +338,26 @@ func BugzillaClient(cmd *cobra.Command) (bugzilla.Client, error) {
 	return bugzilla.NewClient(*generator, endpoint), nil
 }
 
+// OnEngineeringStatus returns a slice of bug status that are blocked on engineering.
+func OnEngineeringStatus() []string {
+	return []string{
+		"NEW",
+		"ASSIGNED",
+		"POST",
+		"ON_DEV",
+	}
+}
+
+// AllOpenStatus returns a slice of bug status that are blocked on engineering, release creation, or quality control.
+func AllOpenStatus() []string {
+	return append(OnEngineeringStatus(), "MODIFIED", "ON_QA")
+}
+
 func getAllOpenBugsQuery() bugzilla.Query {
 	return bugzilla.Query{
 		Classification: []string{"Red Hat"},
 		Product:        []string{"OpenShift Container Platform"},
-		Status:         []string{"NEW", "ASSIGNED", "POST", "ON_DEV", "MODIFIED"},
+		Status:         AllOpenStatus(),
 		IncludeFields:  []string{"id", "summary", "status", "severity", "priority", "assigned_to", "target_release", "component", "sub_components", "keywords", "cf_pm_score", "flags"},
 		Advanced: []bugzilla.AdvancedQuery{
 			{

--- a/pkg/bugs/bugs.go
+++ b/pkg/bugs/bugs.go
@@ -201,6 +201,23 @@ func (orig *BugData) FilterByTargetRelease(sTargets []string) *BugData {
 	return bd
 }
 
+func (orig *BugData) FilterByStatus(statuses []string) *BugData {
+	bd := orig.clone()
+	bugs := bd.GetBugs()
+
+	statusSet := sets.NewString(statuses...)
+	filtered := []*Bug{}
+	for i := range bugs {
+		bug := bugs[i]
+		if !statusSet.Has(bug.Severity) {
+			continue
+		}
+		filtered = append(filtered, bug)
+	}
+	bd.set(filtered)
+	return bd
+}
+
 func (orig *BugData) FilterBySeverity(sSeverities []string) *BugData {
 	bd := orig.clone()
 	bugs := bd.GetBugs()


### PR DESCRIPTION
Because MODIFIED bugs are blocking on ART and ON_QA bugs are blocking on QE, and devs can't directly move either of those along.