### PR TITLE
Update github.com/eparis/bugzilla

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andygrunwald/go-jira v1.12.0
 	github.com/boltdb/bolt v1.3.1
 	github.com/davecgh/go-spew v1.1.1
-	github.com/eparis/bugzilla v0.0.0-20201022181800-66527237a3e8
+	github.com/eparis/bugzilla v0.0.0-20210804000436-c22ec302975f
 	github.com/eparis/goSmartSheet v0.0.6
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/eparis/bugzilla v0.0.0-20201022181800-66527237a3e8 h1:3LAlL+OAqYlC5kFfwVsG58w6dSYoqzAjdIAE71TV87Y=
-github.com/eparis/bugzilla v0.0.0-20201022181800-66527237a3e8/go.mod h1:rL9T9C00qg+aIkHUu2ENFSP49Wx9KwF+uSSF0rml5KQ=
+github.com/eparis/bugzilla v0.0.0-20210804000436-c22ec302975f h1:rMwvYxU39mVsxAy547woG4RjUeryjaK4m33kedmG5Ro=
+github.com/eparis/bugzilla v0.0.0-20210804000436-c22ec302975f/go.mod h1:rL9T9C00qg+aIkHUu2ENFSP49Wx9KwF+uSSF0rml5KQ=
 github.com/eparis/goSmartSheet v0.0.6 h1:B3jSE/bXv2A2NASBVRRCxzyL30ABA8h3SX58ZyT5m8E=
 github.com/eparis/goSmartSheet v0.0.6/go.mod h1:ObuQCSYRvlJCeDfWRHO1dnrslGrtD2hLc9d2VdVWPEM=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/vendor/github.com/eparis/bugzilla/fake.go
+++ b/vendor/github.com/eparis/bugzilla/fake.go
@@ -78,10 +78,23 @@ func (c *Fake) Search(query Query) ([]*Bug, error) {
 	return bugs, nil
 }
 
-// GetBug retrieves the external bugs for the Bugzilla bug,
+// GetExternalBugPRsOnBug retrieves the external bugs for the Bugzilla bug,
 // if registered, or an error, if set, or responds with an
-// error that matches IsNotFound
+// error that matches IsNotFound. It filters them by Github PRs.
 func (c *Fake) GetExternalBugPRsOnBug(id int) ([]ExternalBug, error) {
+	if c.BugErrors.Has(id) {
+		return nil, errors.New("injected error adding external bug to bug")
+	}
+	if _, exists := c.Bugs[id]; exists {
+		return c.ExternalBugs[id], nil
+	}
+	return nil, &requestError{statusCode: http.StatusNotFound, message: "bug not registered in the fake"}
+}
+
+// GetExternalBugs retrieves the external bugs for the Bugzilla bug,
+// if registered, or an error, if set, or responds with an
+// error that matches IsNotFound.
+func (c *Fake) GetExternalBugs(id int) ([]ExternalBug, error) {
 	if c.BugErrors.Has(id) {
 		return nil, errors.New("injected error adding external bug to bug")
 	}

--- a/vendor/github.com/eparis/bugzilla/test_server.go
+++ b/vendor/github.com/eparis/bugzilla/test_server.go
@@ -150,6 +150,10 @@ func (tc testClient) GetExternalBugPRsOnBug(_ int) ([]ExternalBug, error) {
 	return []ExternalBug{}, nil
 }
 
+func (tc testClient) GetExternalBugs(_ int) ([]ExternalBug, error) {
+	return []ExternalBug{}, nil
+}
+
 func (tc testClient) GetBug(id int) (*Bug, error) {
 	srv := tc.getTestServer(tc.path)
 	defer srv.Close()

--- a/vendor/github.com/eparis/bugzilla/types.go
+++ b/vendor/github.com/eparis/bugzilla/types.go
@@ -111,6 +111,10 @@ type Bug struct {
 	Whiteboard string `json:"whiteboard,omitempty"`
 	// DevelWhiteboard is the value of the "devel whiteboard" field on the bug.
 	DevelWhiteboard string `json:"cf_devel_whiteboard,omitempty"`
+	// Escalation is set to "Yes" when this bug is escalated.
+	Escalation string `json:"cf_cust_facing,omitempty"`
+	// ExternalBugs is a list of references to other trackers.
+	ExternalBugs []ExternalBug `json:"external_bugs,omitempty"`
 }
 
 type Comment struct {
@@ -246,7 +250,14 @@ type ExternalBug struct {
 	BugzillaBugID int `json:"bug_id"`
 	// ExternalBugID is a unique identifier for the bug under the tracker
 	ExternalBugID string `json:"ext_bz_bug_id"`
-	// The following fields are parsed from the external bug identifier
+	// ExternalDescription is the description in the external bug system
+	ExternalDescription string `json:"ext_description"`
+	// ExternalPriority is the priority in the external bug system
+	ExternalPriority string `json:"ext_priority"`
+	// ExternalStatus is the external bug status, e.g. Closed (depending on bug system).
+	ExternalStatus string `json:"ext_status"`
+
+	// The following fields are parsed from the external bug identifier for github pulls. These are only filled by GetExternalBugPRsOnBug.
 	Org, Repo string
 	Num       int
 }
@@ -255,6 +266,10 @@ type ExternalBug struct {
 type ExternalBugType struct {
 	// URL is the identifying URL for this tracker
 	URL string `json:"url"`
+	// Description is the tracker name
+	Description string `json:"description"`
+	// Type is the key for the external bug type
+	Type string `json:"type"`
 }
 
 // AddExternalBugParameters are the parameters required to add an external

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -25,7 +25,7 @@ github.com/dgrijalva/jwt-go
 # github.com/emicklei/go-restful v2.9.5+incompatible
 github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
-# github.com/eparis/bugzilla v0.0.0-20201022181800-66527237a3e8
+# github.com/eparis/bugzilla v0.0.0-20210804000436-c22ec302975f
 ## explicit
 github.com/eparis/bugzilla
 # github.com/eparis/goSmartSheet v0.0.6


### PR DESCRIPTION
redhat bugzilla added a new limit of 1000 bugs returned per query. Now
we have to iterate to get all of the bugs. This was implemented in the
client and now we need to vendor the update.