### PR TITLE
Fix build for OCPBugStatus

### DIFF
--- a/pkg/blockerslack/reporters/blockers/blockers_reporter.go
+++ b/pkg/blockerslack/reporters/blockers/blockers_reporter.go
@@ -236,7 +236,7 @@ func triageBug(who string, bugs ...*bugs.Bug) triageResult {
 		r.severityCount[bug.Severity]++
 		r.priorityCount[bug.Priority]++
 
-		if !bug.ReviewedInSprint() && !strings.Contains(bug.TargetRelease, "premerge") {
+		if !bug.ReviewedInSprint() && !bug.HasTargetRelease([]string{"premerge"}) {
 			r.needReviewedInSprintIDs = append(r.needReviewedInSprintIDs, bug.ID)
 		}
 

--- a/pkg/bugs/bugs.go
+++ b/pkg/bugs/bugs.go
@@ -101,6 +101,17 @@ func (b Bug) LowPriorityAndSeverity() bool {
 	return false
 }
 
+func (b Bug) HasTargetRelease(targets []string) bool {
+	for _, bugTarget := range b.TargetRelease {
+		for _, searchTarget := range targets {
+			if bugTarget == searchTarget {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 type PeopleMap map[string][]*Bug
 
 type TeamMap map[string][]*Bug
@@ -188,14 +199,12 @@ func (orig *BugData) FilterByTargetRelease(sTargets []string) *BugData {
 	bd := orig.clone()
 	bugs := orig.GetBugs()
 
-	targets := sets.NewString(sTargets...)
 	filtered := []*Bug{}
 	for i := range bugs {
 		bug := bugs[i]
-		if !targets.Has(bug.TargetRelease[0]) {
-			continue
+		if bug.HasTargetRelease(sTargets) {
+			filtered = append(filtered, bug)
 		}
-		filtered = append(filtered, bug)
 	}
 	bd.set(filtered)
 	return bd


### PR DESCRIPTION
The bug status bot wasn't able to build because it tried to use
bug.TargetRelease as a string when it was an []string

Create a helper to handle TargetRelease easier (and fix the build)