### PR TITLE
blocker_slack: fix Untriaged and and proposed blockers

### DIFF
--- a/cmd/blocker-slack/testBugData
+++ b/cmd/blocker-slack/testBugData
@@ -1,0 +1,1 @@
+../../testData/testBugData

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andygrunwald/go-jira v1.12.0
 	github.com/boltdb/bolt v1.3.1
 	github.com/davecgh/go-spew v1.1.1
-	github.com/eparis/bugzilla v0.0.0-20210804000436-c22ec302975f
+	github.com/eparis/bugzilla v0.0.0-20211202023520-5498e1bd93ef
 	github.com/eparis/goSmartSheet v0.0.6
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/eparis/bugzilla v0.0.0-20210804000436-c22ec302975f h1:rMwvYxU39mVsxAy547woG4RjUeryjaK4m33kedmG5Ro=
-github.com/eparis/bugzilla v0.0.0-20210804000436-c22ec302975f/go.mod h1:rL9T9C00qg+aIkHUu2ENFSP49Wx9KwF+uSSF0rml5KQ=
+github.com/eparis/bugzilla v0.0.0-20211202023520-5498e1bd93ef h1:hgyEas0MZ8Xp1kctbjf/uGTMsSRpBxAH9+DE4xtdhM0=
+github.com/eparis/bugzilla v0.0.0-20211202023520-5498e1bd93ef/go.mod h1:rL9T9C00qg+aIkHUu2ENFSP49Wx9KwF+uSSF0rml5KQ=
 github.com/eparis/goSmartSheet v0.0.6 h1:B3jSE/bXv2A2NASBVRRCxzyL30ABA8h3SX58ZyT5m8E=
 github.com/eparis/goSmartSheet v0.0.6/go.mod h1:ObuQCSYRvlJCeDfWRHO1dnrslGrtD2hLc9d2VdVWPEM=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/pkg/bugs/bugs.go
+++ b/pkg/bugs/bugs.go
@@ -82,10 +82,10 @@ func (b Bug) BlockerRequested() bool {
 }
 
 func (b Bug) Untriaged() bool {
-	if b.Severity == "---" {
+	if b.Severity == "unspecified" || b.Severity == "" {
 		return true
 	}
-	if b.Priority == "---" {
+	if b.Priority == "unspecified" || b.Priority == "" {
 		return true
 	}
 	if b.BlockerRequested() {

--- a/vendor/github.com/eparis/bugzilla/test_server.go
+++ b/vendor/github.com/eparis/bugzilla/test_server.go
@@ -86,7 +86,12 @@ func (tc *testClient) handleGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (tc *testClient) handleQuery(w http.ResponseWriter, r *http.Request) {
-	bugs := tc.getBugList()
+	offset := r.URL.Query().Get("offset")
+	bugs := BugList{}
+	if offset == "0" {
+		bugs = tc.getBugList()
+	}
+
 	b, err := json.Marshal(bugs)
 	if err != nil {
 		fmt.Printf("Unable to marshal bug data: %v\n", err)
@@ -139,7 +144,7 @@ func (tc testClient) UpdateBug(_ int, _ BugUpdate) error {
 	return nil
 }
 
-func (tc testClient) Search(query Query) ([]*Bug, error) {
+func (tc *testClient) Search(query Query) ([]*Bug, error) {
 	srv := tc.getTestServer(tc.path)
 	defer srv.Close()
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -25,7 +25,7 @@ github.com/dgrijalva/jwt-go
 # github.com/emicklei/go-restful v2.9.5+incompatible
 github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
-# github.com/eparis/bugzilla v0.0.0-20210804000436-c22ec302975f
+# github.com/eparis/bugzilla v0.0.0-20211202023520-5498e1bd93ef
 ## explicit
 github.com/eparis/bugzilla
 # github.com/eparis/goSmartSheet v0.0.6


### PR DESCRIPTION
The 'untriaged' bugs incorrectly were testing for --- when it should have tested for 'unspecified'.  So that was actually just showing all blocker? bugs.  This was a useful thing to show, so show that directly and make 'untriaged' actually show untriaged.