### PR TITLE
blockerslack: remove debug code that only looked at install team

### DIFF
--- a/pkg/blockerslack/reporters/blockers/blockers_reporter.go
+++ b/pkg/blockerslack/reporters/blockers/blockers_reporter.go
@@ -350,9 +350,6 @@ func (c *BlockersReporter) sync(ctx context.Context, syncCtx factory.SyncContext
 func Report(ctx context.Context, orgData *teams.OrgData, bugData *bugs.BugData, recorder events.Recorder, config *config.OperatorConfig) (peopleNotificationMap notificationMap, teamNotificationMap notificationMap) {
 	teamsWithChannel := []string{}
 	for team, teamInfo := range orgData.Teams {
-		if team != "OpenShift Installer" {
-			continue
-		}
 		if teamInfo.SlackChan != "" {
 			teamsWithChannel = append(teamsWithChannel, team)
 		}


### PR DESCRIPTION
When debugging I limited it to a single team, then committed and merged
that code.  Whoops.