### PR TITLE
Explicitly set Bugzilla auth method to Bearer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/andygrunwald/go-jira v1.12.0
 	github.com/boltdb/bolt v1.3.1
 	github.com/davecgh/go-spew v1.1.1
-	github.com/eparis/bugzilla v0.0.0-20211202023520-5498e1bd93ef
+	github.com/eparis/bugzilla v0.0.0-20220216154903-c21b4ad3cb14
 	github.com/eparis/goSmartSheet v0.0.6
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/eparis/bugzilla v0.0.0-20211202023520-5498e1bd93ef h1:hgyEas0MZ8Xp1kctbjf/uGTMsSRpBxAH9+DE4xtdhM0=
-github.com/eparis/bugzilla v0.0.0-20211202023520-5498e1bd93ef/go.mod h1:rL9T9C00qg+aIkHUu2ENFSP49Wx9KwF+uSSF0rml5KQ=
+github.com/eparis/bugzilla v0.0.0-20220216154903-c21b4ad3cb14 h1:rNs8NT2h0WL27PUWekZUYgzY2ShlWQJGQFaofAguUD0=
+github.com/eparis/bugzilla v0.0.0-20220216154903-c21b4ad3cb14/go.mod h1:rL9T9C00qg+aIkHUu2ENFSP49Wx9KwF+uSSF0rml5KQ=
 github.com/eparis/goSmartSheet v0.0.6 h1:B3jSE/bXv2A2NASBVRRCxzyL30ABA8h3SX58ZyT5m8E=
 github.com/eparis/goSmartSheet v0.0.6/go.mod h1:ObuQCSYRvlJCeDfWRHO1dnrslGrtD2hLc9d2VdVWPEM=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/pkg/bugs/bugs.go
+++ b/pkg/bugs/bugs.go
@@ -344,7 +344,11 @@ func BugzillaClient(cmd *cobra.Command) (bugzilla.Client, error) {
 	}
 	generator = &generatorFunc
 
-	return bugzilla.NewClient(*generator, endpoint), nil
+	client := bugzilla.NewClient(*generator, endpoint)
+	if err := client.SetAuthMethod(bugzilla.AuthBearer); err != nil {
+		return nil, err
+	}
+	return client, nil
 }
 
 func getAllOpenBugsQuery() bugzilla.Query {

--- a/vendor/github.com/eparis/bugzilla/fake.go
+++ b/vendor/github.com/eparis/bugzilla/fake.go
@@ -18,6 +18,7 @@ package bugzilla
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -140,6 +141,14 @@ func (c *Fake) AddPullRequestAsExternalBug(id int, org, repo string, num int) (b
 		return true, nil
 	}
 	return false, &requestError{statusCode: http.StatusNotFound, message: "bug not registered in the fake"}
+}
+
+// SetAuthMethod doesn't do anything and you can only set a blank string
+func (c *Fake) SetAuthMethod(authMethod string) error {
+	if authMethod != "" {
+		return fmt.Errorf("Only support blank authmethod")
+	}
+	return nil
 }
 
 // the Fake is a Client

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -25,7 +25,7 @@ github.com/dgrijalva/jwt-go
 # github.com/emicklei/go-restful v2.9.5+incompatible
 github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
-# github.com/eparis/bugzilla v0.0.0-20211202023520-5498e1bd93ef
+# github.com/eparis/bugzilla v0.0.0-20220216154903-c21b4ad3cb14
 ## explicit
 github.com/eparis/bugzilla
 # github.com/eparis/goSmartSheet v0.0.6


### PR DESCRIPTION
Red Hat bugzilla is going to start invalidating API tokens if they use the query string auth format. Bearer is the only supported method going forward. This PR rebases github.com/eparis/bugzilla to allow explicit auth method choice and then uses the bearer method.