### PR TITLE
Propose blockers by PM score

### DIFF
--- a/cmd/bug-automation/generate/main.go
+++ b/cmd/bug-automation/generate/main.go
@@ -241,6 +241,18 @@ func bugsNeedBlockerFlagPriorityQuery() bugzilla.Query {
 	return query
 }
 
+func bugsNeedBlockerFlagPmScoreQuery() bugzilla.Query {
+	query := needsBlockerFlagQuery()
+	query.Advanced = append(query.Advanced, []bugzilla.AdvancedQuery{
+		{
+			Field: "cf_pm_score",
+			Op:    "greaterthan",
+			Value: "140",
+		},
+	}...)
+	return query
+}
+
 func bugsNeedBlockerFlagAction() bugzilla.BugUpdate {
 	return bugzilla.BugUpdate{
 		Flags: []bugzilla.FlagChange{
@@ -342,6 +354,13 @@ func doGenerate() error {
 			Name:        "bugsNeedBlockerFlagPriority",
 			Description: "All bugs that should have at least blocker? based on the priority",
 			Query:       bugsNeedBlockerFlagPriorityQuery(),
+			Update:      bugsNeedBlockerFlagAction(),
+			Default:     true,
+		},
+		{
+			Name:        "bugsNeedBlockerFlagPmScore",
+			Description: "All bugs that have PM score greater than 140",
+			Query:       bugsNeedBlockerFlagPmScoreQuery(),
 			Update:      bugsNeedBlockerFlagAction(),
 			Default:     true,
 		},

--- a/cmd/bug-automation/operations/bugsNeedBlockerFlagPmScore.yaml
+++ b/cmd/bug-automation/operations/bugsNeedBlockerFlagPmScore.yaml
@@ -1,0 +1,49 @@
+default: true
+description: All bugs that have PM score greater than 140
+name: bugsNeedBlockerFlagPmScore
+query:
+  advanced:
+  - field: component
+    negate: true
+    op: equals
+    value: Documentation
+  - field: component
+    negate: true
+    op: equals
+    value: Migration Tooling
+  - field: component
+    negate: true
+    op: equals
+    value: odo
+  - field: flagtypes.name
+    negate: true
+    op: substring
+    value: blocker
+  - field: target_release
+    op: notregexp
+    value: ^4\.[0-9]+\.z$|premerge$
+  - field: version
+    op: notregexp
+    value: ^2\.
+  - field: version
+    op: notregexp
+    value: ^3\.
+  - field: cf_pm_score
+    op: greaterthan
+    value: "140"
+  classification:
+  - Red Hat
+  include_fields:
+  - id
+  product:
+  - OpenShift Container Platform
+  status:
+  - NEW
+  - ASSIGNED
+  - POST
+  - ON_DEV
+update:
+  flags:
+  - name: blocker
+    status: '?'
+  minor_update: true


### PR DESCRIPTION
I'm trying to improve the ratio of proposed / approved blockers and would like to get rid of automatic proposals based just on severity and priority. One of the ideas coming from the discussions was to propose the blocking bugs based on PM score (which includes sev/prio, I can explain why I chose 140 as the PM score threshold). This is the first step towards the goal. So far it should be basically no-op since it would target subset of the bugs selected by sev/prio.

Please let me know what you think.